### PR TITLE
Setup development VM with Vagrant

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ yacs.db
 yacs.environment
 tags
 celerybeat-schedule
+.vagrant/

--- a/README.md
+++ b/README.md
@@ -75,12 +75,17 @@ Install the appropriate driver and its database, or just use the bundled SQLite.
 
 #### Vagrant
 
-[Vagrant][vagrant] is a tool which builds a development VM. The VM for YACS is based on [terrywant/archlinux][archbase] and is provisioned by `vagrant.sh`. The development environment is contained in a python [virtualenv][virtualenv] by [berdario/pew][pew].
+[Vagrant][vagrant] is a tool which builds a development VM. The VM for
+YACS is based on [terrywant/archlinux][archbase] and is provisioned by
+`vagrant.sh`. The development environment is contained in a python
+[virtualenv][] by [berdario/pew][pew]. The development instance is
+configured to use [PostgreSQL][postgresql].
 
 [vagrant]:https://www.vagrantup.com/
 [archbase]:https://github.com/terrywang/vagrantboxes/blob/master/archlinux-x86_64.md
 [virtualenv]:https://github.com/pypa/virtualenv
 [pew]:https://github.com/berdario/pew
+[postgresql]:http://www.postgresql.org/
 
 After you have vagrant installed, to start developing, just:
 

--- a/README.md
+++ b/README.md
@@ -73,6 +73,25 @@ Install the appropriate driver and its database, or just use the bundled SQLite.
 [local]: http://localhost:8000/
 [django admin]: http://localhost:8000/admin/
 
+#### Vagrant
+
+[Vagrant][vagrant] is a tool which builds a development VM. The VM for YACS is based on [terrywant/archlinux][archbase] and is provisioned by `vagrant.sh`. The development environment is contained in a python [virtualenv][virtualenv] by [berdario/pew][pew].
+
+[vagrant]:https://www.vagrantup.com/
+[archbase]:https://github.com/terrywang/vagrantboxes/blob/master/archlinux-x86_64.md
+[virtualenv]:https://github.com/pypa/virtualenv
+[pew]:https://github.com/berdario/pew
+
+After you have vagrant installed, to start developing, just:
+
+1. `vagrant up` to boot and provision the VM.
+2. `cd /vagrant && pew workon yacs` to get in the working environment.
+3. Do as step 3-6 above.
+
+Notes:
+- `/vagrant` is shared between the host and the VM, so you can use whatever you like in the host to develop.
+- Port 8000 is forwarded so the default preview works the same, but if you want to change the port number you have to forward that in the `Vagrantfile` as well.
+
 ## Setup (Production)
 
 It's probably best to use the associated project: [seafood][]. Which is a [salt][]

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -56,6 +56,14 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # View the documentation for the provider you're using for more
   # information on available options.
 
+  # Enable provisioning with shell.
+  #
+  # config.vm.provision "shell", path: "vagrant.sh"
+  #
+  # Test
+  config.vm.define "test", autostart:false do |test|
+    test.vm.provision "shell", path: "test.sh"
+  end
   # Enable provisioning with CFEngine. CFEngine Community packages are
   # automatically installed. For example, configure the host as a
   # policy server and optionally a policy file to run:

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -58,12 +58,12 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
   # Enable provisioning with shell.
   #
-  # config.vm.provision "shell", path: "vagrant.sh"
+   config.vm.provision "shell", path: "vagrant.sh"
   #
   # Test
-  config.vm.define "test", autostart:false do |test|
-    test.vm.provision "shell", path: "test.sh"
-  end
+  #config.vm.define "test", autostart:false do |test|
+  #  test.vm.provision "shell", path: "vagrant.sh"
+  #end
   # Enable provisioning with CFEngine. CFEngine Community packages are
   # automatically installed. For example, configure the host as a
   # policy server and optionally a policy file to run:

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -58,12 +58,9 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
   # Enable provisioning with shell.
   #
-   config.vm.provision "shell", path: "vagrant.sh"
+  config.vm.provision "shell", path: "vagrant.sh"
   #
   # Test
-  #config.vm.define "test", autostart:false do |test|
-  #  test.vm.provision "shell", path: "vagrant.sh"
-  #end
   # Enable provisioning with CFEngine. CFEngine Community packages are
   # automatically installed. For example, configure the host as a
   # policy server and optionally a policy file to run:

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -20,11 +20,11 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # Create a forwarded port mapping which allows access to a specific port
   # within the machine from a port on the host machine. In the example below,
   # accessing "localhost:8080" will access port 80 on the guest machine.
-  config.vm.network "forwarded_port", guest: 80, host: 80
+  config.vm.network "forwarded_port", guest: 8000, host: 8000
 
   # Create a private network, which allows host-only access to the machine
   # using a specific IP.
-  config.vm.network "private_network", ip: "192.168.33.10"
+  # config.vm.network "private_network", ip: "192.168.33.10"
 
   # Create a public network, which generally matched to bridged network.
   # Bridged networks make the machine appear as another physical device on

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,122 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# Vagrantfile API/syntax version. Don't touch unless you know what you're doing!
+VAGRANTFILE_API_VERSION = "2"
+
+Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+  # All Vagrant configuration is done here. The most common configuration
+  # options are documented and commented below. For a complete reference,
+  # please see the online documentation at vagrantup.com.
+
+  # Every Vagrant virtual environment requires a box to build off of.
+  config.vm.box = "terrywang/archlinux"
+
+  # Disable automatic box update checking. If you disable this, then
+  # boxes will only be checked for updates when the user runs
+  # `vagrant box outdated`. This is not recommended.
+  # config.vm.box_check_update = false
+
+  # Create a forwarded port mapping which allows access to a specific port
+  # within the machine from a port on the host machine. In the example below,
+  # accessing "localhost:8080" will access port 80 on the guest machine.
+  config.vm.network "forwarded_port", guest: 80, host: 80
+
+  # Create a private network, which allows host-only access to the machine
+  # using a specific IP.
+  config.vm.network "private_network", ip: "192.168.33.10"
+
+  # Create a public network, which generally matched to bridged network.
+  # Bridged networks make the machine appear as another physical device on
+  # your network.
+  # config.vm.network "public_network"
+
+  # If true, then any SSH connections made will enable agent forwarding.
+  # Default value: false
+  # config.ssh.forward_agent = true
+
+  # Share an additional folder to the guest VM. The first argument is
+  # the path on the host to the actual folder. The second argument is
+  # the path on the guest to mount the folder. And the optional third
+  # argument is a set of non-required options.
+  # config.vm.synced_folder "../data", "/vagrant_data"
+
+  # Provider-specific configuration so you can fine-tune various
+  # backing providers for Vagrant. These expose provider-specific options.
+  # Example for VirtualBox:
+  #
+  # config.vm.provider "virtualbox" do |vb|
+  #   # Don't boot with headless mode
+  #   vb.gui = true
+  #
+  #   # Use VBoxManage to customize the VM. For example to change memory:
+  #   vb.customize ["modifyvm", :id, "--memory", "1024"]
+  # end
+  #
+  # View the documentation for the provider you're using for more
+  # information on available options.
+
+  # Enable provisioning with CFEngine. CFEngine Community packages are
+  # automatically installed. For example, configure the host as a
+  # policy server and optionally a policy file to run:
+  #
+  # config.vm.provision "cfengine" do |cf|
+  #   cf.am_policy_hub = true
+  #   # cf.run_file = "motd.cf"
+  # end
+  #
+  # You can also configure and bootstrap a client to an existing
+  # policy server:
+  #
+  # config.vm.provision "cfengine" do |cf|
+  #   cf.policy_server_address = "10.0.2.15"
+  # end
+
+  # Enable provisioning with Puppet stand alone.  Puppet manifests
+  # are contained in a directory path relative to this Vagrantfile.
+  # You will need to create the manifests directory and a manifest in
+  # the file default.pp in the manifests_path directory.
+  #
+  # config.vm.provision "puppet" do |puppet|
+  #   puppet.manifests_path = "manifests"
+  #   puppet.manifest_file  = "default.pp"
+  # end
+
+  # Enable provisioning with chef solo, specifying a cookbooks path, roles
+  # path, and data_bags path (all relative to this Vagrantfile), and adding
+  # some recipes and/or roles.
+  #
+  # config.vm.provision "chef_solo" do |chef|
+  #   chef.cookbooks_path = "../my-recipes/cookbooks"
+  #   chef.roles_path = "../my-recipes/roles"
+  #   chef.data_bags_path = "../my-recipes/data_bags"
+  #   chef.add_recipe "mysql"
+  #   chef.add_role "web"
+  #
+  #   # You may also specify custom JSON attributes:
+  #   chef.json = { mysql_password: "foo" }
+  # end
+
+  # Enable provisioning with chef server, specifying the chef server URL,
+  # and the path to the validation key (relative to this Vagrantfile).
+  #
+  # The Opscode Platform uses HTTPS. Substitute your organization for
+  # ORGNAME in the URL and validation key.
+  #
+  # If you have your own Chef Server, use the appropriate URL, which may be
+  # HTTP instead of HTTPS depending on your configuration. Also change the
+  # validation key to validation.pem.
+  #
+  # config.vm.provision "chef_client" do |chef|
+  #   chef.chef_server_url = "https://api.opscode.com/organizations/ORGNAME"
+  #   chef.validation_key_path = "ORGNAME-validator.pem"
+  # end
+  #
+  # If you're using the Opscode platform, your validator client is
+  # ORGNAME-validator, replacing ORGNAME with your organization name.
+  #
+  # If you have your own Chef Server, the default validation client name is
+  # chef-validator, unless you changed the configuration.
+  #
+  #   chef.validation_client_name = "ORGNAME-validator"
+end

--- a/vagrant.sh
+++ b/vagrant.sh
@@ -1,0 +1,39 @@
+#!/bin/sh
+
+# install external dependency
+sudo pacman -Sy --noconfirm --needed postgresql libmemcached python2-pip
+
+# setup virtualenv
+pip2 install pew --user
+PATH=$HOME/.local/bin:$PATH
+export WORKON_HOME=$HOME/.pew
+pew new -r /vagrant/requirements.txt -d yacs
+
+# setup PATH
+touch ~/.profile
+sed -i '$a\
+\
+# pip user scheme PATH\
+PATH="$HOME/.local/bin:$PATH"\
+\
+# pew virtualenv dir\
+export WORKON_HOME=$HOME/.pew
+' ~/.profile
+
+# setup postgresql
+sudo su -c "pg_ctl -D ~/data initdb" postgres
+sudo systemctl start postgresql
+sudo su postgres <<EOF
+createdb yacsdb
+psql -c 'CREATE USER yacs' yacsdb
+EOF
+
+# setup project
+(
+cd /vagrant
+pew-in yacs python manage.py migrate
+pew-in yacs python manage.py import_course_data   # imports from RPI SIS + PDFs
+pew-in yacs python manage.py import_catalog_data  # imports from RPI course catalog
+pew-in yacs python manage.py create_section_cache # creates cache for generating schedules
+psql -c "UPDATE courses_semester SET visible=TRUE WHERE id=1;" yacsdb yacs # make latest semester visible
+)

--- a/vagrant.sh
+++ b/vagrant.sh
@@ -1,39 +1,34 @@
 #!/bin/sh
 
+# update package managers
+pacman -Sy --noconfirm pacman package-query
+pacman-db-upgrade
+
 # install external dependency
-sudo pacman -Sy --noconfirm --needed postgresql libmemcached python2-pip
+pacman -S --noconfirm --needed postgresql libmemcached python-pip
+
+# setup postgresql
+su -c "pg_ctl -D ~/data initdb" postgres
+systemctl start postgresql
+su postgres <<EOF
+createdb yacsdb
+psql -c 'CREATE USER yacs' yacsdb
+EOF
 
 # setup virtualenv
-pip2 install pew --user
-PATH=$HOME/.local/bin:$PATH
-export WORKON_HOME=$HOME/.pew
-pew new -r /vagrant/requirements.txt -d yacs
+su vagrant <<EOF
+yaourt -S --noconfirm python-pew
 
-# setup PATH
 touch ~/.profile
 sed -i '$a\
-\
-# pip user scheme PATH\
-PATH="$HOME/.local/bin:$PATH"\
 \
 # pew virtualenv dir\
 export WORKON_HOME=$HOME/.pew
 ' ~/.profile
 
-# setup postgresql
-sudo su -c "pg_ctl -D ~/data initdb" postgres
-sudo systemctl start postgresql
-sudo su postgres <<EOF
-createdb yacsdb
-psql -c 'CREATE USER yacs' yacsdb
 EOF
 
 # setup project
-(
-cd /vagrant
-pew-in yacs python manage.py migrate
-pew-in yacs python manage.py import_course_data   # imports from RPI SIS + PDFs
-pew-in yacs python manage.py import_catalog_data  # imports from RPI course catalog
-pew-in yacs python manage.py create_section_cache # creates cache for generating schedules
-psql -c "UPDATE courses_semester SET visible=TRUE WHERE id=1;" yacsdb yacs # make latest semester visible
-)
+su vagrant <<EOF
+pew new -p python2 -r /vagrant/requirements.txt -d yacs
+EOF

--- a/yacs/settings/development.py
+++ b/yacs/settings/development.py
@@ -15,7 +15,7 @@ DATABASES = {
         'ENGINE': 'django.db.backends.postgresql_psycopg2',
         'NAME': 'yacsdb',
         'USER': 'yacs',
-        'PASSWORD': 'yacs',
+        'PASSWORD': 'NULL', # using trust auth via localhost
         'HOST': '127.0.0.1',
         'PORT': '5432',
     }

--- a/yacs/settings/development.py
+++ b/yacs/settings/development.py
@@ -9,3 +9,14 @@ CACHES = {
         'VERSION': CACHE_VERSION,
     }
 }
+
+DATABASES = {
+    'default': {
+        'ENGINE': 'django.db.backends.postgresql_psycopg2',
+        'NAME': 'yacsdb',
+        'USER': 'yacs',
+        'PASSWORD': 'yacs',
+        'HOST': '127.0.0.1',
+        'PORT': '5432',
+    }
+}

--- a/yacs/settings/development.py
+++ b/yacs/settings/development.py
@@ -15,7 +15,7 @@ DATABASES = {
         'ENGINE': 'django.db.backends.postgresql_psycopg2',
         'NAME': 'yacsdb',
         'USER': 'yacs',
-        'PASSWORD': 'NULL', # using trust auth via localhost
+        'PASSWORD': 'NULL',    # using trust auth via localhost
         'HOST': '127.0.0.1',
         'PORT': '5432',
     }


### PR DESCRIPTION
This branch adds setting files for Vagrant to setup a VM for developing YACS. The usage is explained in README/Setup/Setup(development)/Vagrant section.
